### PR TITLE
Compare filesize of Bynder file match iPMC file before save

### DIFF
--- a/BynderExtension/Workers/AssetDownloadWorker.cs
+++ b/BynderExtension/Workers/AssetDownloadWorker.cs
@@ -1,4 +1,5 @@
-﻿using Bynder.Api;
+﻿using System.Collections.Generic;
+using Bynder.Api;
 using Bynder.Api.Model;
 using Bynder.Names;
 using inRiver.Remoting.Extension;
@@ -26,8 +27,8 @@ namespace Bynder.Workers
                 resourceEntity = _inRiverContext.ExtensionManager.DataService.GetEntity(resourceEntity.Id, LoadLevel.DataOnly);
             }
 
-            string bynderDownloadState =
-                (string)resourceEntity.GetField(FieldTypeIds.ResourceBynderDownloadState)?.Data;
+            var bynderDownloadStateField = resourceEntity.GetField(FieldTypeIds.ResourceBynderDownloadState);
+            string bynderDownloadState = (string)bynderDownloadStateField?.Data;
 
             if (string.IsNullOrWhiteSpace(bynderDownloadState) || bynderDownloadState != BynderStates.Todo) return;
 
@@ -39,31 +40,56 @@ namespace Bynder.Workers
             if (asset == null)
             {
                 _inRiverContext.Log(LogLevel.Error, "Asset information is empty");
+
+                bynderDownloadStateField.Data = BynderStates.Error;
+                _inRiverContext.ExtensionManager.DataService.UpdateFieldsForEntity(new List<Field> { bynderDownloadStateField });
+
                 return;
             }
 
             // check for existing file
             var resourceFileId = resourceEntity.GetField(FieldTypeIds.ResourceFileId)?.Data;
-            int existingFileId = resourceFileId != null ? (int)resourceFileId : 0;
+            var existingFileId = (int?)resourceFileId ?? 0;
 
-            // add new asset
-            string resourceFileName = (string)resourceEntity.GetField(FieldTypeIds.ResourceFilename)?.Data;
-            int newFileId = _inRiverContext.ExtensionManager.UtilityService.AddFileFromUrl(resourceFileName, _bynderClient.GetAssetDownloadLocation(asset.Id).S3_File);
+            // download the asset
+            var file = _bynderClient.DownloadAsset(asset.Id);
+            if (file == null)
+            {
+                _inRiverContext.Log(LogLevel.Error, $"Could not download asset with Id {asset.Id}");
 
-            // delete older asset file
+                bynderDownloadStateField.Data = BynderStates.Error;
+                _inRiverContext.ExtensionManager.DataService.UpdateFieldsForEntity(new List<Field> { bynderDownloadStateField });
+
+                return;
+            }
+
             if (existingFileId > 0)
             {
+                // check if existing ResourceFile is same size as the one in Bynder
+                var resourceFileMetaData = _inRiverContext.ExtensionManager.UtilityService.GetFileMetaData(existingFileId);
+                if (file.LongLength == resourceFileMetaData.FileSize)
+                {
+                    _inRiverContext.Log(LogLevel.Debug, "Asset is the same as before. Setting the state to Done.");
+                    bynderDownloadStateField.Data = BynderStates.Done;
+                    _inRiverContext.ExtensionManager.DataService.UpdateFieldsForEntity(new List<Field> { bynderDownloadStateField });
+                    return;
+                }
+                // delete older asset file
                 _inRiverContext.Log(LogLevel.Verbose, $"existing fileId found {existingFileId}");
                 _inRiverContext.ExtensionManager.UtilityService.DeleteFile(existingFileId);
             }
 
+            // add new asset
+            string resourceFileName = (string)resourceEntity.GetField(FieldTypeIds.ResourceFilename)?.Data;
+            int newFileId = _inRiverContext.ExtensionManager.UtilityService.AddFile(resourceFileName, file);
+
             // set fieltypes for resource entity
             resourceEntity.GetField(FieldTypeIds.ResourceFileId).Data = newFileId;
             resourceEntity.GetField(FieldTypeIds.ResourceMimeType).Data = asset.GetOriginalMimeType();
-            resourceEntity.GetField(FieldTypeIds.ResourceBynderDownloadState).Data = BynderStates.Done;
+            bynderDownloadStateField.Data = BynderStates.Done;
 
             _inRiverContext.ExtensionManager.DataService.UpdateEntity(resourceEntity);
-            _inRiverContext.Logger.Log(LogLevel.Information, $"Updated resource entity {resourceEntity.Id}");
+            _inRiverContext.Log(LogLevel.Information, $"Updated resource entity {resourceEntity.Id}");
         }
     }
 }


### PR DESCRIPTION
There is no need to download it if is still the same binary file in iPMC and Bynder. 

This happens when you run the Schedule extension with force. That will set all Download states to `todo` and will update all ResourceFIleId Fields, which is a trigger that the File was changed. This is not the case if the still have the same size. 